### PR TITLE
Add summary page and download option

### DIFF
--- a/app/controllers/spree/admin/back_in_stock_notifications_controller.rb
+++ b/app/controllers/spree/admin/back_in_stock_notifications_controller.rb
@@ -7,9 +7,14 @@ module Spree
 
       def index
         @back_in_stock_notifications = @back_in_stock_notifications
+          .pending
           .order(updated_at: :desc)
           .page params[:page]
-          # .pending
+
+        respond_to do |format|
+          format.html
+          format.csv { send_data @back_in_stock_notifications.to_csv }
+        end
       end
 
       def summary

--- a/app/controllers/spree/admin/back_in_stock_notifications_controller.rb
+++ b/app/controllers/spree/admin/back_in_stock_notifications_controller.rb
@@ -1,12 +1,51 @@
 module Spree
   module Admin
     class BackInStockNotificationsController < ResourceController
+      before_action :set_filter_params, only: :summary
+      before_action :set_stock_locations, only: :summary
+      before_action :set_back_in_stock_notifications, only: :summary
 
       def index
         @back_in_stock_notifications = @back_in_stock_notifications
           .order(updated_at: :desc)
           .page params[:page]
           # .pending
+      end
+
+      def summary
+        @back_in_stock_notifications_summary = Spree::BackInStockNotification.pending
+          .where(stock_location_option)
+          .group(:variant).count
+          .map { |v,n| [v, n] }
+          .sort_by { |x| sort_value(*x) }
+
+        @back_in_stock_notifications_summary = @back_in_stock_notifications_summary.reverse unless params[:sort_by] == "sku"
+      end
+
+      private
+
+      def sort_value(variant, count)
+        if params[:sort_by] == "sku"
+          variant.sku
+        else
+          count
+        end
+      end
+
+      def set_filter_params
+        @filter_params = params.permit(:sort_by, :stock_location_id)
+      end
+
+      def stock_location_option
+        @stock_location_option || params[:stock_location_id] ? {stock_location_id: params[:stock_location_id]} : {}
+      end
+
+      def set_stock_locations
+        @stock_locations = Spree::StockLocation.select(:id, :name)
+      end
+
+      def set_back_in_stock_notifications
+        @back_in_stock_notifications = Spree::BackInStockNotification.pending.where(stock_location_option)
       end
     end
   end

--- a/app/models/spree/back_in_stock_notification.rb
+++ b/app/models/spree/back_in_stock_notification.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class Spree::BackInStockNotification < ApplicationRecord
   paginates_per 50
 
@@ -30,5 +32,35 @@ class Spree::BackInStockNotification < ApplicationRecord
 
   def pending?
     email_sent_at.nil?
+  end
+
+  def self.to_csv
+    CSV.generate do |csv|
+      csv << [
+        "id",
+        "product",
+        "label",
+        "sku",
+        "email",
+        "stock_location",
+        "country_iso",
+        "locale",
+        "email_sent_count",
+      ]
+
+      pending.each do |bisn|
+        back_in_stock_notification_values = []
+        back_in_stock_notification_values << bisn.id
+        back_in_stock_notification_values << bisn.product.name
+        back_in_stock_notification_values << bisn.label
+        back_in_stock_notification_values << bisn.variant.sku
+        back_in_stock_notification_values << bisn.email
+        back_in_stock_notification_values << bisn.stock_location.name
+        back_in_stock_notification_values << bisn.country_iso
+        back_in_stock_notification_values << bisn.locale
+        back_in_stock_notification_values << bisn.email_sent_count
+        csv << back_in_stock_notification_values
+      end
+    end
   end
 end

--- a/app/views/spree/admin/back_in_stock_notifications/_download_button.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/_download_button.html.erb
@@ -1,0 +1,8 @@
+<% content_for :page_actions do %>
+  <li id="download-csv">
+    <%= link_to_with_icon 'download', "Download CSV",
+      spree.admin_back_in_stock_notifications_path(format: "csv"),
+      class: 'btn btn-primary'
+    %>
+  </li>
+<% end %>

--- a/app/views/spree/admin/back_in_stock_notifications/_summary_filters.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/_summary_filters.html.erb
@@ -1,0 +1,20 @@
+<div class="btn-group" style="margin-bottom:10px;">
+  <div class="dropdown">
+    <button class="btn btn-secondary dropdown-toggle" type="button" id="zoneDropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Stock Location
+    </button>
+    <div class="dropdown-menu" aria-labelledby="zoneDropdownMenuButton">
+      <%= link_to summary_admin_back_in_stock_notifications_path(@filter_params.merge({stock_location_id: nil})), class: "dropdown-item"  do %>
+        Any stock location
+      <% end %>
+      <div class="dropdown-divider"></div>
+      <% @stock_locations.each do |stock_location| %>
+        <%= link_to summary_admin_back_in_stock_notifications_path(@filter_params.merge({stock_location_id: stock_location.id})),
+          class: "dropdown-item", style: "font-size: 11px" do %>
+
+          <%= stock_location.name %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/spree/admin/back_in_stock_notifications/_tabs.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/_tabs.html.erb
@@ -1,0 +1,13 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class="tabs" data-hook="admin_back_in_stock_notification_tabs">
+      <%= content_tag :li, class: "fa #{ 'active' if params[:action] == "summary" }" do %>
+        <%= link_to "Summary", spree.summary_admin_back_in_stock_notifications_path %>
+      <% end %>
+
+      <%= content_tag :li, class: "fa #{ 'active' if params[:action] == "index" }" do %>
+        <%= link_to "Requests", spree.admin_back_in_stock_notifications_path %>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/spree/admin/back_in_stock_notifications/_totals.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/_totals.html.erb
@@ -1,0 +1,10 @@
+<p style="margin-bottom: 20px">
+  Total pending requests: <%= @back_in_stock_notifications.count %><br>
+
+  Variants requested:
+    <%= @back_in_stock_notifications_summary.count %>
+    <% product_count = @back_in_stock_notifications_summary.map{ |variant, count| variant.product_id }.uniq.count %>
+    from <%= product_count %> <%= "product".pluralize(product_count) %><br>
+
+  Number of customers: <%= @back_in_stock_notifications.group(:email).count.count %>
+</p>

--- a/app/views/spree/admin/back_in_stock_notifications/index.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/index.html.erb
@@ -1,5 +1,6 @@
 
 <% admin_breadcrumb(link_to "Back in stock notifications", spree.admin_back_in_stock_notifications_path) %>
+<% admin_breadcrumb("Requests") %>
 
 <% content_for :page_actions do %>
   <% if false #can?(:create, Spree::BackInStockNotification) %>
@@ -13,6 +14,8 @@
     </li>
   <% end %>
 <% end %>
+
+<%= render "tabs" %>
 
 <div id="new_back_in_stock_notification"></div>
 

--- a/app/views/spree/admin/back_in_stock_notifications/index.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/index.html.erb
@@ -61,7 +61,7 @@
     </tbody>
   </table>
 
-  <%= paginate @back_in_stock_notifications %>
+  <%= paginate @back_in_stock_notifications, theme: "solidus_admin" %>
 <% else %>
   <div class="no-objects-found">
     No Back in stock notification found.

--- a/app/views/spree/admin/back_in_stock_notifications/index.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/index.html.erb
@@ -15,6 +15,7 @@
   <% end %>
 <% end %>
 
+<%= render "download_button" %>
 <%= render "tabs" %>
 
 <div id="new_back_in_stock_notification"></div>

--- a/app/views/spree/admin/back_in_stock_notifications/summary.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/summary.html.erb
@@ -1,0 +1,33 @@
+<% admin_breadcrumb(link_to "Back in stock notifications", spree.admin_back_in_stock_notifications_path) %>
+<% admin_breadcrumb("Summary") %>
+
+<%= render "tabs" %>
+<%= render "totals" %>
+<%= render "summary_filters" %>
+
+<% if @back_in_stock_notifications_summary.any? %>
+  <table class="index" id="listing_back_in_stock_notifications">
+    <thead>
+      <tr data-hook="back_in_stock_notification_header">
+        <th><%=t "spree.product" %></th>
+        <th><%= link_to "SKU #{'▼' if params[:sort_by] == 'sku'}", summary_admin_back_in_stock_notifications_path(sort_by: :sku) %></th>
+        <th><%= link_to "Count #{'▼' unless params[:sort_by] == 'sku'}", summary_admin_back_in_stock_notifications_path(sort_by: :count) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @back_in_stock_notifications_summary.each do |variant, count| %>
+        <tr class="spree_back_in_stock_notifications_summary" data-hook="back_in_stock_notifications_summary_row">
+          <td><%= link_to_if can?(:edit, variant.product), "#{variant.name}", spree.edit_admin_product_path(variant.product) %></td>
+          <td><%= link_to_if can?(:edit, variant), variant.sku, spree.edit_admin_product_variant_path(variant.product, variant) %></td>
+          <td><%= count %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+<% else %>
+  <div class="no-objects-found">
+    There are no notifications to summarise
+    <%= "for this stock location" if params[:stock_location_id] %>.
+  </div>
+<% end %>

--- a/app/views/spree/admin/back_in_stock_notifications/summary.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/summary.html.erb
@@ -1,6 +1,8 @@
 <% admin_breadcrumb(link_to "Back in stock notifications", spree.admin_back_in_stock_notifications_path) %>
 <% admin_breadcrumb("Summary") %>
 
+
+<%= render "download_button" %>
 <%= render "tabs" %>
 <%= render "totals" %>
 <%= render "summary_filters" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@
 
 Spree::Core::Engine.routes.draw do
   namespace :admin do
-    resources :back_in_stock_notifications
+    resources :back_in_stock_notifications do
+      collection do
+        get :summary
+      end
+    end
   end
 
   resources :back_in_stock_notifications, only: [:new, :create, :update, :show]

--- a/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
+++ b/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
@@ -38,6 +38,26 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
           end
         end
       end
+
+      context "format CSV" do
+        subject { get :index, params: { format: :csv } }
+
+        let!(:bisn) { create(:back_in_stock_notification) }
+        let(:stock_location) { bisn.stock_location }
+        let(:product) { bisn.product }
+        let(:variant) { bisn.variant }
+
+
+        it "returns the expected CSV contents" do
+          subject
+          expect( CSV.parse(response.body) ).to eq (
+            [
+              ["id",          "product",         "label",         "sku",            "email",         "stock_location",        "country_iso", "locale", "email_sent_count"],
+              ["#{bisn.id}",  "#{product.name}", "Perfect Peach", "#{variant.sku}", "#{bisn.email}", "#{stock_location.name}", "GB",         "en",     "0"]
+            ]
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
* Adds summary page showing the back in stock notification request counts by variant
* Create a CSV download option for for pending back in stock notification requests