### PR TITLE
Add a new job to handle mailer and mark that email has been sent

### DIFF
--- a/app/jobs/back_in_stock_notification_email_job.rb
+++ b/app/jobs/back_in_stock_notification_email_job.rb
@@ -4,27 +4,20 @@ class BackInStockNotificationEmailJob < ApplicationJob
   def perform(stock_location_params: {})
     @stock_location_params = stock_location_params.slice(:id, :name)
 
-    send_back_in_stock_notifications
-  end
-
-  private
-
-  def send_back_in_stock_notifications
-    in_stock_user_notifications.each do |email, user_bisns|
-      Spree::BackInStockNotificationMailer.notification(user_bisns).deliver_now
-
-      user_bisns.each do |bisn|
-        bisn.email_sent_at = Time.current
-        bisn.email_sent_count += 1
-        bisn.save!
+    stock_locations.each do |stock_location|
+      emails_of_ready_to_send(stock_location).each do |email|
+        BackInStockNotificationMailerJob.perform_later(email: email, stock_location: stock_location)
       end
     end
   end
 
-  def in_stock_user_notifications
-    # notifications for items back in stock and grouped by email
-    Spree::StockLocation.where(@stock_location_params).inject([]) { |sum, stock_location|
-      sum += Spree::BackInStockNotification.pending.in_stock(stock_location)
-    }.uniq.group_by(&:email)
+  private
+
+  def stock_locations
+    Spree::StockLocation.where(@stock_location_params)
+  end
+
+  def emails_of_ready_to_send(stock_location)
+    Spree::BackInStockNotification.emails_of_ready_to_send(stock_location)
   end
 end

--- a/app/jobs/back_in_stock_notification_mailer_job.rb
+++ b/app/jobs/back_in_stock_notification_mailer_job.rb
@@ -1,0 +1,15 @@
+class BackInStockNotificationMailerJob < ApplicationJob
+
+  def perform(email:, stock_location:)
+    user_bisns = Spree::BackInStockNotification.ready_to_send_by_email(email, stock_location)
+    return unless user_bisns.present?
+
+    Spree::BackInStockNotificationMailer.notification(user_bisns).deliver_now
+
+    user_bisns.each do |bisn|
+      bisn.email_sent_at = Time.current
+      bisn.email_sent_count += 1
+      bisn.save!
+    end
+  end
+end

--- a/spec/jobs/back_in_stock_notification_email_job_spec.rb
+++ b/spec/jobs/back_in_stock_notification_email_job_spec.rb
@@ -8,6 +8,7 @@ describe BackInStockNotificationEmailJob do
 
     context "with one pending stock notification" do
       let!(:bisn) { create(:back_in_stock_notification) }
+      let(:stock_location) { bisn.stock_location }
 
       context "item is backorderable" do
         before { bisn.variant.stock_items.update_all backorderable: true }
@@ -15,33 +16,24 @@ describe BackInStockNotificationEmailJob do
         context "for all stock locations" do
           let(:stock_location_params) { {} }
 
-          it "sends the email" do
-            expect { subject }
-              .to change {
-                n = Spree::BackInStockNotification.find(bisn.id)
-                [n.pending?, n.email_sent_count]
-              }
-              .from([true, 0]).to([false, 1])
+          it "calls the mailer job" do
+            expect{ subject }.to have_enqueued_job(BackInStockNotificationMailerJob)
           end
         end
 
         context "for matching stock location name" do
-          let(:stock_location_params) { {name: bisn.stock_location.name} }
+          let(:stock_location_params) { {name: stock_location.name} }
 
-          it "sends the email" do
-            expect { subject }
-              .to change { Spree::BackInStockNotification.find(bisn.id).pending? }
-              .from(true).to(false)
+          it "calls the mailer job" do
+            expect{ subject }.to have_enqueued_job(BackInStockNotificationMailerJob)
           end
         end
 
         context "for matching stock location id" do
           let(:stock_location_params) { {id: bisn.stock_location.id} }
 
-          it "sends the email" do
-            expect { subject }
-              .to change { Spree::BackInStockNotification.find(bisn.id).pending? }
-              .from(true).to(false)
+          it "calls the mailer job" do
+            expect{ subject }.to have_enqueued_job(BackInStockNotificationMailerJob)
           end
         end
 
@@ -49,10 +41,8 @@ describe BackInStockNotificationEmailJob do
           let(:stock_location) { create(:stock_location, name: "New Stock Location" ) }
           let(:stock_location_params) { {name: stock_location.name} }
 
-          it "does not send the email" do
-            expect { subject }
-              .to_not change { Spree::BackInStockNotification.find(bisn.id).pending? }
-              .from(true)
+          it "does not call the mailer job" do
+            expect{ subject }.to_not have_enqueued_job(BackInStockNotificationMailerJob)
           end
         end
       end
@@ -65,13 +55,8 @@ describe BackInStockNotificationEmailJob do
           context "for all stock locations" do
             let(:stock_location_params) { {} }
 
-            it "sends the email" do
-              expect { subject }
-                .to change {
-                  n = Spree::BackInStockNotification.find(bisn.id)
-                  [n.pending?, n.email_sent_count]
-                }
-                .from([true, 0]).to([false, 1])
+            it "calls the mailer job" do
+              expect{ subject }.to have_enqueued_job(BackInStockNotificationMailerJob)
             end
           end
         end
@@ -82,13 +67,8 @@ describe BackInStockNotificationEmailJob do
           context "for all stock locations" do
             let(:stock_location_params) { {} }
 
-            it "sends the email" do
-              expect { subject }
-                .to_not change {
-                  n = Spree::BackInStockNotification.find(bisn.id)
-                  [n.pending?, n.email_sent_count]
-                }
-                .from([true, 0])
+            it "does not call the mailer job" do
+              expect{ subject }.to_not have_enqueued_job(BackInStockNotificationMailerJob)
             end
           end
         end
@@ -103,9 +83,8 @@ describe BackInStockNotificationEmailJob do
         context "for all stock locations" do
           let(:stock_location_params) { {} }
 
-          it "does not send an email" do
-            expect { subject }
-              .to_not change { Spree::BackInStockNotification.find(bisn.id).email_sent_count }
+          it "does not call the mailer job" do
+            expect{ subject }.to_not have_enqueued_job(BackInStockNotificationMailerJob)
           end
         end
       end

--- a/spec/jobs/back_in_stock_notification_mailer_job_spec.rb
+++ b/spec/jobs/back_in_stock_notification_mailer_job_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe BackInStockNotificationMailerJob do
+  describe '#perform' do
+    subject { described_class.new(email: email, stock_location: stock_location).perform_now }
+    let(:email) { bisn.email }
+    let(:stock_location) { bisn.stock_location }
+
+    let!(:store) { create(:store) }
+
+    context "with one pending stock notification" do
+      let!(:bisn) { create(:back_in_stock_notification) }
+
+      context "item is backorderable" do
+        before { bisn.variant.stock_items.update_all backorderable: true }
+
+        it "records email was sent" do
+          expect { subject }
+            .to change {
+              n = Spree::BackInStockNotification.find(bisn.id)
+              [n.pending?, n.email_sent_count]
+            }
+            .from([true, 0]).to([false, 1])
+        end
+
+        it "sends the email" do
+          expect{ subject }.to change { Spree::BackInStockNotificationMailer.deliveries.count }.by(1)
+        end
+      end
+
+      context "item not backorderable" do
+
+        context "item is in stock" do
+          before { bisn.variant.stock_items.update_all backorderable: false, count_on_hand: 50 }
+
+          it "sends the email" do
+            expect{ subject }.to change { Spree::BackInStockNotificationMailer.deliveries.count }.by(1)
+          end
+        end
+      end
+
+      context "item is out of stock" do
+        before { bisn.variant.stock_items.update_all backorderable: false, count_on_hand: 0 }
+
+        it "does not send an email" do
+          expect{ subject }.to_not change { Spree::BackInStockNotificationMailer.deliveries.count }
+        end
+      end
+    end
+
+    context "with one complete stock notification" do
+      context "item is backorderable" do
+        before { bisn.variant.stock_items.update_all backorderable: true }
+        let!(:bisn) { create(:back_in_stock_notification, email_sent_at: 1.hour.ago) }
+
+        it "does not send an email" do
+          expect{ subject }.to_not change { Spree::BackInStockNotificationMailer.deliveries.count }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a separate Mailer job to call mailer
Record when the notification was sent in this new job.

This ensures the job is not overloaded by attempting to send too
many emails at once and helps avoid the situation where emails are
sent multple times when the job fails halfway through and retries.