### PR TITLE
Remove email from CSV download

### DIFF
--- a/app/models/spree/back_in_stock_notification.rb
+++ b/app/models/spree/back_in_stock_notification.rb
@@ -41,7 +41,6 @@ class Spree::BackInStockNotification < ApplicationRecord
         "product",
         "label",
         "sku",
-        "email",
         "stock_location",
         "country_iso",
         "locale",
@@ -54,7 +53,6 @@ class Spree::BackInStockNotification < ApplicationRecord
         back_in_stock_notification_values << bisn.product.name
         back_in_stock_notification_values << bisn.label
         back_in_stock_notification_values << bisn.variant.sku
-        back_in_stock_notification_values << bisn.email
         back_in_stock_notification_values << bisn.stock_location.name
         back_in_stock_notification_values << bisn.country_iso
         back_in_stock_notification_values << bisn.locale

--- a/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
+++ b/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
           subject
           expect( CSV.parse(response.body) ).to eq (
             [
-              ["id",          "product",         "label",         "sku",            "email",         "stock_location",        "country_iso", "locale", "email_sent_count"],
-              ["#{bisn.id}",  "#{product.name}", "Perfect Peach", "#{variant.sku}", "#{bisn.email}", "#{stock_location.name}", "GB",         "en",     "0"]
+              ["id",          "product",         "label",         "sku",            "stock_location",         "country_iso", "locale", "email_sent_count"],
+              ["#{bisn.id}",  "#{product.name}", "Perfect Peach", "#{variant.sku}", "#{stock_location.name}", "GB",          "en",     "0"]
             ]
           )
         end


### PR DESCRIPTION
This is to avoid data protection issues.

This could be another reason to add a "Back in Stock" user model for this so an ID could be included in the CSV download if needed for analysis of predicted demand. E.g. one user might show interest in many shades of grey but only be interested in buying the first one that comes back in stock.