### PR TITLE
Allow another product to be associated to bisn requests

### DIFF
--- a/app/controllers/spree/admin/back_in_stock_notifications_controller.rb
+++ b/app/controllers/spree/admin/back_in_stock_notifications_controller.rb
@@ -8,7 +8,7 @@ module Spree
       def index
         @back_in_stock_notifications = @back_in_stock_notifications
           .pending
-          .includes(:stock_location, variant: :product)
+          .includes(:stock_location, :product, variant: :product)
           .order(updated_at: :desc)
 
         respond_to do |format|

--- a/app/controllers/spree/back_in_stock_notifications_controller.rb
+++ b/app/controllers/spree/back_in_stock_notifications_controller.rb
@@ -3,7 +3,7 @@ module Spree
 
     def create
       @back_in_stock_notification = Spree::BackInStockNotification
-        .where(back_in_stock_notification_params.slice(:email, :variant_id))
+        .where(back_in_stock_notification_params.slice(:email, :variant_id, :product_id))
         .where.not(email_sent_at: nil)
         .first_or_initialize(options)
 
@@ -17,7 +17,7 @@ module Spree
     def back_in_stock_notification_params
       @back_in_stock_notification_params ||= params
         .require(:back_in_stock_notification)
-        .permit(:label, :variant_id, :locale, :country_iso, :email, :user_id)
+        .permit(:label, :variant_id, :product_id, :locale, :country_iso, :email, :user_id)
     end
 
     def options

--- a/app/mailers/spree/back_in_stock_notification_mailer.rb
+++ b/app/mailers/spree/back_in_stock_notification_mailer.rb
@@ -59,8 +59,7 @@ module Spree
     end
 
     def product_image_link(bisn)
-      line_item = Spree::LineItem.new(variant: bisn.variant)
-      image = WATG::Presenters::LineItem.new(line_item).image
+      image = bisn.product.images.first
       "https:#{image&.attachment(:product)}"
     end
 

--- a/app/views/spree/admin/back_in_stock_notifications/index.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/index.html.erb
@@ -32,7 +32,6 @@
         <th><%=t "spree.language" %></th>
         <th><%=t "spree.stock" %></th>
         <th><%=t "spree.location" %></th>
-        <th><%=t "spree.email_sent" %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -42,12 +41,11 @@
           <td>
             <%= link_to_if (bisn.user && can?(:idit, bisn.user)), bisn.email, admin_user_path(bisn.user || '') %>
           </td>
-          <td><%= link_to_if can?(:edit, bisn.product), "#{bisn.variant.name} - #{bisn.label}", spree.edit_admin_product_path(bisn.product) %></td>
-          <td><%= link_to_if can?(:edit, bisn.variant), bisn.variant.sku, spree.edit_admin_product_variant_path(bisn.product, bisn.variant) %></td>
+          <td><%= link_to_if can?(:edit, bisn.product), "#{bisn.product_name} - #{bisn.label}", spree.edit_admin_product_path(bisn.product) %></td>
+          <td><%= link_to_if can?(:edit, bisn.variant), bisn.variant.sku, spree.edit_admin_product_variant_path(bisn.variant.product, bisn.variant) %></td>
           <td><%= bisn.locale %></td>
           <td><%= bisn.stock_count %></td>
           <td><%= link_to bisn.stock_location.name, spree.edit_admin_stock_location_path(bisn.stock_location) %></td>
-          <td><%= bisn.email_sent_at || "-" %></td>
 
           <td class="actions">
             <% if false #can?(:update, bisn) %>

--- a/app/views/spree/back_in_stock_notification_mailer/_back_in_stock_item.html.erb
+++ b/app/views/spree/back_in_stock_notification_mailer/_back_in_stock_item.html.erb
@@ -23,12 +23,12 @@
                 <div style="text-align: left;">
                   <span style="font-size:14px">
                     <span style="font-family:arial,helvetica neue,helvetica,sans-serif">
-                      <strong><%= bisn.label %></strong> <%= bisn.variant.name %>
+                      <strong><%= bisn.label %></strong> <%= bisn.product_name %>
                     </span>
                   </span>
                   <br>
                   <span style="font-size:14px">
-                    <strong>Price: </strong><%= bisn.variant.price_in(currency).display_price %>
+                    <strong>Price: </strong><%= bisn.product.price_in(currency).display_price %>
                   </span>
                   <div>
                     <%= link_to product_link, title: t("spree.back_in_stock.email.go_to_product"), target: :_blank do %>

--- a/db/migrate/20210208171722_add_product_id_to_spree_back_in_stock_notifications.rb
+++ b/db/migrate/20210208171722_add_product_id_to_spree_back_in_stock_notifications.rb
@@ -1,0 +1,12 @@
+class AddProductIdToSpreeBackInStockNotifications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_back_in_stock_notifications, :product_id, :integer
+    add_index :spree_back_in_stock_notifications, :product_id
+
+    # Associate any previous notification requests to the variant product
+    # The column is needed to associate requests to a product kit where the variant is a component
+    Spree::BackInStockNotification.includes(:variant).find_each do |bisn|
+      bisn.update_column :product_id, bisn.variant.product_id
+    end
+  end
+end

--- a/lib/solidus_back_in_stock/testing_support/factories.rb
+++ b/lib/solidus_back_in_stock/testing_support/factories.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     email_sent_count { 0 }
 
     variant { |v| v.association(:variant) }
+    product { |v| v.association(:product) }
     user { |v| v.association(:user) }
     stock_location { |v| v.association(:stock_location) }
   end

--- a/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
+++ b/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
           subject
           expect( CSV.parse(response.body) ).to eq (
             [
-              ["id",          "product",         "label",         "sku",            "stock_location",         "country_iso", "locale", "email_sent_count"],
-              ["#{bisn.id}",  "#{product.name}", "Perfect Peach", "#{variant.sku}", "#{stock_location.name}", "GB",          "en",     "0"]
+              ["id",          "product",              "label",         "product_sku",    "variant_sku",    "stock_location",         "country_iso", "locale", "email_sent_count"],
+              ["#{bisn.id}",  "#{bisn.product_name}", "Perfect Peach", "#{product.sku}", "#{variant.sku}", "#{stock_location.name}", "GB",          "en",     "0"]
             ]
           )
         end

--- a/spec/models/spree/back_in_stock_notification_spec.rb
+++ b/spec/models/spree/back_in_stock_notification_spec.rb
@@ -11,6 +11,32 @@ RSpec.describe Spree::BackInStockNotification do
           .to change { described_class.count }
           .from(0).to(1)
       end
+
+      context "when no product_id is given" do
+        let!(:variant) { create(:variant) }
+        let(:back_in_stock_notification) { build(:back_in_stock_notification, variant: variant) }
+        before { back_in_stock_notification.product_id = nil }
+
+        it "sets the product_id to the variant product_id" do
+          subject
+          back_in_stock_notification.reload
+          expect( back_in_stock_notification.product_id ).to eq variant.product_id
+        end
+      end
+
+      context "when no product_id is given" do
+        let!(:variant) { create(:variant) }
+        let!(:product) { create(:product) }
+        let(:back_in_stock_notification) { build(:back_in_stock_notification, variant: variant) }
+        before { back_in_stock_notification.product_id = product.id }
+
+        it "sets the product_id to the variant product_id" do
+          subject
+          back_in_stock_notification.reload
+          expect( variant.product_id ).to_not eq product.id
+          expect( back_in_stock_notification.product_id ).to eq product.id
+        end
+      end
     end
 
     context "when the email is missing" do


### PR DESCRIPTION
This is to enable the back in stock notifications work with kits such
that the kit name can be included in the email notification when the
component variant returns back in stock. If no product ID is provided
then it is set to the oos variant product ID.

Admin pages, CSV download and email template is also updated to make use of this new relation.