### PR TITLE
Upgrade extension with solidus_support and test with ruby 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 orbs:
+  # Required for feature specs.
+  browser-tools: circleci/browser-tools@1.1
+
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
   # to change this configuration every time a Solidus version is released
@@ -9,23 +12,17 @@ orbs:
 
 jobs:
   run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
+    executor:
+      name: solidusio_extensions/postgres
+      ruby_version: '3.2'
     steps:
+      # - browser-tools/install-chrome
       - solidusio_extensions/run-tests
-  run-specs-with-mysql:
-    executor: solidusio_extensions/mysql
-    steps:
-      - solidusio_extensions/run-tests
-  lint-code:
-    executor: solidusio_extensions/sqlite-memory
-    steps:
-      - solidusio_extensions/lint-code
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs-with-postgres
-      # - run-specs-with-mysql
       # - lint-code
 
   "Weekly run specs against main":
@@ -38,4 +35,3 @@ workflows:
                 - main
     jobs:
       - run-specs-with-postgres
-      # - run-specs-with-mysql

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .sass-cache
 coverage
 Gemfile.lock
+Gemfile-local
 tmp
 nbproject
 pkg

--- a/Gemfile
+++ b/Gemfile
@@ -3,18 +3,30 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'v2.8.6')
+# Set which Solidus version you wish to use by running the export command first:
+# export SOLIDUS_BRANCH=v2.11.15
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
+
+# The solidus_frontend gem has been pulled out since v3.2
+if branch >= 'v3.2'
+  gem 'solidus_frontend'
+elsif branch == 'main'
+  gem 'solidus_frontend', github: 'solidusio/solidus_frontend'
+else
+  gem 'solidus_frontend', github: 'solidusio/solidus', branch: branch
+end
 
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.
 # See https://github.com/bundler/bundler/issues/6677
-gem 'rails', '>0.a'
+gem 'rails', ">0.a"
+
 
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
-case ENV['DB']
+case ENV.fetch('DB', nil)
 when 'mysql'
   gem 'mysql2'
 when 'postgresql'
@@ -22,7 +34,6 @@ when 'postgresql'
 else
   gem 'sqlite3'
 end
-
 
 group :development, :test do
   gem 'byebug'
@@ -32,6 +43,11 @@ group :development, :test do
   gem 'letter_opener'
   gem 'rails-controller-testing'
 end
+
+# While we still support Ruby < 3 we need to workaround a limitation in
+# the 'async' gem that relies on the latest ruby, since RubyGems doesn't
+# resolve gems based on the required ruby version.
+gem 'async', '< 3' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3')
 
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bundler/gem_tasks"
 require 'solidus_dev_support/rake_tasks'
 SolidusDevSupport::RakeTasks.install
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -1,29 +1,23 @@
 #!/usr/bin/env bash
 
 set -e
+test -z "${DEBUG+empty_string}" || set -x
 
-case "$DB" in
-postgres|postgresql)
-  RAILSDB="postgresql"
-  ;;
-mysql)
-  RAILSDB="mysql"
-  ;;
-sqlite|'')
-  RAILSDB="sqlite3"
-  ;;
-*)
-  echo "Invalid DB specified: $DB"
-  exit 1
-  ;;
-esac
+test "$DB" = "sqlite" && export DB="sqlite3"
 
-if [ ! -z $SOLIDUS_BRANCH ]
+if [ -z "$SOLIDUS_BRANCH" ]
 then
-  BRANCH=$SOLIDUS_BRANCH
-else
-  BRANCH="master"
+  echo "~~> Use 'export SOLIDUS_BRANCH=[main|v3.2|...]' to control the Solidus branch"
+  SOLIDUS_BRANCH="main"
 fi
+echo "~~> Using branch $SOLIDUS_BRANCH of solidus"
+
+if [ -z "$SOLIDUS_FRONTEND" ]
+then
+  echo "~~> Use 'export SOLIDUS_FRONTEND=[solidus_frontend|solidus_starter_frontend]' to control the Solidus frontend"
+  SOLIDUS_FRONTEND="solidus_frontend"
+fi
+echo "~~> Using branch $SOLIDUS_FRONTEND as the solidus frontend"
 
 extension_name="solidus_back_in_stock"
 
@@ -33,7 +27,8 @@ function unbundled {
 }
 
 rm -rf ./sandbox
-unbundled bundle exec rails new sandbox --database="$RAILSDB" \
+unbundled bundle exec rails new sandbox \
+  --database="${DB:-sqlite3}" \
   --skip-bundle \
   --skip-git \
   --skip-keeps \
@@ -49,8 +44,7 @@ fi
 
 cd ./sandbox
 cat <<RUBY >> Gemfile
-gem 'solidus', github: 'solidusio/solidus', branch: '$BRANCH'
-gem 'solidus_auth_devise', '>= 2.1.0'
+gem 'solidus', github: 'solidusio/solidus', branch: '$SOLIDUS_BRANCH'
 gem 'rails-i18n'
 gem 'solidus_i18n'
 
@@ -67,20 +61,18 @@ unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create
 
-unbundled bundle exec rails generate spree:install \
+unbundled bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
-  --with-authentication=false \
+  --with-authentication=true \
   --payment-method=none \
+  --frontend=${SOLIDUS_FRONTEND} \
   $@
 
-unbundled bundle exec rails generate solidus:auth:install
-unbundled bundle exec rails generate ${extension_name}:install
+unbundled bundle exec rails generate solidus:auth:install --auto-run-migrations
+unbundled bundle exec rails generate ${extension_name}:install --auto-run-migrations
 
 echo
 echo "🚀 Sandbox app successfully created for $extension_name!"
-echo "🚀 Using $RAILSDB and Solidus $BRANCH"
-echo "🚀 Use 'export DB=[postgres|mysql|sqlite]' to control the DB adapter"
-echo "🚀 Use 'export SOLIDUS_BRANCH=<BRANCH-NAME>' to control the Solidus version"
-echo "🚀 This app is intended for test purposes."
+echo "🧪 This app is intended for test purposes."

--- a/config/initializers/solidus_back_in_stock.rb
+++ b/config/initializers/solidus_back_in_stock.rb
@@ -1,7 +1,0 @@
-# This initializer is just used for testing this extension and should generally match
-# the template that is installed to the apps that use this extension that is located here:
-# lib/generators/solidus_back_in_stock/install/templates/initializer.rb
-
-SolidusBackInStock.configure do |config|
-  config.back_in_stock_threshold = 0
-end

--- a/lib/generators/solidus_back_in_stock/install/install_generator.rb
+++ b/lib/generators/solidus_back_in_stock/install/install_generator.rb
@@ -6,6 +6,10 @@ module SolidusBackInStock
       class_option :auto_run_migrations, type: :boolean, default: false
       source_root File.expand_path('templates', __dir__)
 
+      def self.exit_on_failure?
+        true
+      end
+
       def copy_initializer
         template 'initializer.rb', 'config/initializers/solidus_back_in_stock.rb'
       end

--- a/lib/solidus_back_in_stock.rb
+++ b/lib/solidus_back_in_stock.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'solidus_core'
-require 'solidus_support'
-
 require 'solidus_back_in_stock/configuration'
 require 'solidus_back_in_stock/version'
 require 'solidus_back_in_stock/engine'

--- a/lib/solidus_back_in_stock/configuration.rb
+++ b/lib/solidus_back_in_stock/configuration.rb
@@ -2,7 +2,7 @@
 
 module SolidusBackInStock
   class Configuration
-    # Define here the settings for this extensions, e.g.:
+    # Define here the settings for this extension, e.g.:
     #
     # attr_accessor :my_setting
 

--- a/lib/solidus_back_in_stock/engine.rb
+++ b/lib/solidus_back_in_stock/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/core'
+require 'solidus_core'
+require 'solidus_support'
 require 'solidus_back_in_stock'
 
 module SolidusBackInStock

--- a/solidus_back_in_stock.gemspec
+++ b/solidus_back_in_stock.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |spec|
   spec.license = 'BSD-3-Clause'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/watg/watg-solidus'
-  spec.metadata['changelog_uri'] = 'https://github.com/watg/watg-solidus/blob/master/CHANGELOG.md'
+  spec.metadata['source_code_uri'] = 'https://github.com/watg/solidus_back_in_stock'
+  spec.metadata['changelog_uri'] = 'https://github.com/watg/solidus_back_in_stock/blob/main/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.7')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5', '< 4')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -29,9 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.5'
-  spec.add_dependency 'psych', '< 4'
 
-  spec.add_development_dependency 'solidus_dev_support', '~> 2.2'
+  spec.add_development_dependency 'solidus_dev_support', '~> 2.7'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,9 @@ require 'solidus_dev_support/rspec/feature_helper'
 # in spec/support/ and its subdirectories.
 Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 
-# Requires factories defined in lib/solidus_back_in_stock/testing_support/factories.rb
-require 'solidus_back_in_stock/testing_support/factories'
+# Requires factories defined in Solidus core and this extension.
+# See: lib/solidus_back_in_stock/testing_support/factories.rb
+SolidusDevSupport::TestingSupport::Factories.load_for(SolidusBackInStock::Engine)
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
The extension is upgraded with `bundle exec solidus extension .` to include the latest Solidus extension conventions and resolve the failing extension tests for the latest Solidus versions.

To run the tests locally following this upgrade run the following: 
$ export SOLIDUS_BRANCH=v2.11.15 # or whatever Solidus version you want to use 
$ bundle update
$ rm -r spec/dummy
$ ./bin/sandbox
$ ./bin/rake