### PR TITLE
Add request dates to summary page and download

### DIFF
--- a/app/models/spree/back_in_stock_notification.rb
+++ b/app/models/spree/back_in_stock_notification.rb
@@ -77,6 +77,7 @@ class Spree::BackInStockNotification < ApplicationRecord
         "country_iso",
         "locale",
         "email_sent_count",
+        "request_date"
       ]
 
       pending.each do |bisn|
@@ -90,6 +91,7 @@ class Spree::BackInStockNotification < ApplicationRecord
         back_in_stock_notification_values << bisn.country_iso
         back_in_stock_notification_values << bisn.locale
         back_in_stock_notification_values << bisn.email_sent_count
+        back_in_stock_notification_values << bisn.updated_at.strftime("%Y-%m-%d")
         csv << back_in_stock_notification_values
       end
     end

--- a/app/models/spree/back_in_stock_notification.rb
+++ b/app/models/spree/back_in_stock_notification.rb
@@ -36,6 +36,14 @@ class Spree::BackInStockNotification < ApplicationRecord
       .in_stock(stock_location)
   end
 
+  def self.ransackable_associations(auth_object = nil)
+    %w[product stock_location user variant]
+  end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[stock_location_id updated_at]
+  end
+
   def self.emails_of_ready_to_send(stock_location)
     pending.in_stock(stock_location).pluck(:email)
   end

--- a/app/views/spree/admin/back_in_stock_notifications/_summary_filters.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/_summary_filters.html.erb
@@ -1,20 +1,47 @@
-<div class="btn-group" style="margin-bottom:10px;">
-  <div class="dropdown">
-    <button class="btn btn-secondary dropdown-toggle" type="button" id="zoneDropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Stock Location
-    </button>
-    <div class="dropdown-menu" aria-labelledby="zoneDropdownMenuButton">
-      <%= link_to summary_admin_back_in_stock_notifications_path(@filter_params.merge({stock_location_id: nil})), class: "dropdown-item"  do %>
-        Any stock location
-      <% end %>
-      <div class="dropdown-divider"></div>
-      <% @stock_locations.each do |stock_location| %>
-        <%= link_to summary_admin_back_in_stock_notifications_path(@filter_params.merge({stock_location_id: stock_location.id})),
-          class: "dropdown-item", style: "font-size: 11px" do %>
+<div class="btn-group" style="margin-bottom:30px;">
+  <%= search_form_for [:admin, @search], url: summary_admin_back_in_stock_notifications_path do |f| %>
+    <div class="row">
+      <div class="col-4">
+        <div class="field">
+          <%= label_tag :q_stock_location_id_eq, Spree::StockLocation.model_name.human %><br>
+          <%= f.collection_select :stock_location_id_eq,
+            @stock_locations,
+            :id,
+            :name,
+            {include_blank: t("spree.match_choices.all")},
+            {class: "custom-select fullwidth"}
+          %>
+        </div>
+      </div>
 
-          <%= stock_location.name %>
-        <% end %>
-      <% end %>
+      <div class="col-6">
+        <div class="date-range-filter field">
+          <%= label_tag :updated_at_gt, "Requested Date Range" %>
+          <div class="date-range-fields input-group">
+            <%= f.text_field :updated_at_gt,
+              class: "datepicker form-control datepicker-from",
+              value: params.dig(:q, :updated_at_gt),
+              placeholder: t("spree.start")
+            %>
+
+            <span class="range-divider input-group-addon">
+              <i class="fa fa-arrow-right"></i>
+            </span>
+
+            <%= f.text_field :updated_at_lt,
+              class: "datepicker form-control datepicker-to",
+              value: params.dig(:q, :updated_at_lt),
+              placeholder: t("spree.stop")
+            %>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
+
+    <div class="actions filter-actions">
+      <div data-hook="admin_promotions_index_search_buttons">
+        <%= button_tag t("spree.filter_results"), class: "btn btn-primary" %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/spree/admin/back_in_stock_notifications/summary.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/summary.html.erb
@@ -12,6 +12,7 @@
     <thead>
       <tr data-hook="back_in_stock_notification_header">
         <th><%=t "spree.product" %></th>
+        <th><%=t "spree.options" %></th>
         <th><%= link_to "SKU #{'▼' if params[:sort_by] == 'sku'}", summary_admin_back_in_stock_notifications_path(@filter_params.merge(sort_by: :sku)) %></th>
         <th><%= link_to "Count #{'▼' unless params[:sort_by] == 'sku'}", summary_admin_back_in_stock_notifications_path(@filter_params.merge(sort_by: :count)) %></th>
       </tr>
@@ -20,6 +21,7 @@
       <% @back_in_stock_notifications_summary.each do |variant, count| %>
         <tr class="spree_back_in_stock_notifications_summary" data-hook="back_in_stock_notifications_summary_row">
           <td><%= link_to_if can?(:edit, variant.product), "#{variant.name}", spree.edit_admin_product_path(variant.product) %></td>
+          <td><%= variant.options_text %></td>
           <td><%= link_to_if can?(:edit, variant), variant.sku, spree.edit_admin_product_variant_path(variant.product, variant) %></td>
           <td><%= count %></td>
         </tr>

--- a/app/views/spree/admin/back_in_stock_notifications/summary.html.erb
+++ b/app/views/spree/admin/back_in_stock_notifications/summary.html.erb
@@ -12,8 +12,8 @@
     <thead>
       <tr data-hook="back_in_stock_notification_header">
         <th><%=t "spree.product" %></th>
-        <th><%= link_to "SKU #{'▼' if params[:sort_by] == 'sku'}", summary_admin_back_in_stock_notifications_path(sort_by: :sku) %></th>
-        <th><%= link_to "Count #{'▼' unless params[:sort_by] == 'sku'}", summary_admin_back_in_stock_notifications_path(sort_by: :count) %></th>
+        <th><%= link_to "SKU #{'▼' if params[:sort_by] == 'sku'}", summary_admin_back_in_stock_notifications_path(@filter_params.merge(sort_by: :sku)) %></th>
+        <th><%= link_to "Count #{'▼' unless params[:sort_by] == 'sku'}", summary_admin_back_in_stock_notifications_path(@filter_params.merge(sort_by: :count)) %></th>
       </tr>
     </thead>
     <tbody>
@@ -30,6 +30,5 @@
 <% else %>
   <div class="no-objects-found">
     There are no notifications to summarise
-    <%= "for this stock location" if params[:stock_location_id] %>.
   </div>
 <% end %>

--- a/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
+++ b/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
@@ -47,13 +47,16 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
         let(:product) { bisn.product }
         let(:variant) { bisn.variant }
 
+        before do
+          bisn.update_column :updated_at, Date.parse("2023-01-02")
+        end
 
         it "returns the expected CSV contents" do
           subject
           expect( CSV.parse(response.body) ).to eq (
             [
-              ["id",          "product",              "label",         "product_sku",    "variant_sku",    "stock_location",         "country_iso", "locale", "email_sent_count"],
-              ["#{bisn.id}",  "#{bisn.product_name}", "Perfect Peach", "#{product.sku}", "#{variant.sku}", "#{stock_location.name}", "GB",          "en",     "0"]
+              ["id",          "product",              "label",         "product_sku",    "variant_sku",    "stock_location",         "country_iso", "locale", "email_sent_count", "request_date"],
+              ["#{bisn.id}",  "#{bisn.product_name}", "Perfect Peach", "#{product.sku}", "#{variant.sku}", "#{stock_location.name}", "GB",          "en",     "0", "2023-01-02"]
             ]
           )
         end

--- a/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
+++ b/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
       end
 
       context "format CSV" do
-        subject { get :index, params: { format: :csv } }
+        subject { get :index, params: {format: :csv} }
 
         let!(:bisn) { create(:back_in_stock_notification) }
         let(:stock_location) { bisn.stock_location }
@@ -99,8 +99,7 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
 
               it "returns the expected results" do
                 subject
-                expect( assigns(:back_in_stock_notifications_summary).map{|v,c| [v.sku, c]} )
-                  .to eq [[variant_2.sku, 2], [variant_1.sku, 1]]
+                expect(assigns(:back_in_stock_notifications_summary)).to eq [[variant_2, 2], [variant_1, 1]]
               end
 
               context "order by sku" do
@@ -108,8 +107,7 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
 
                 it "returns the expected results ordered by sku" do
                   subject
-                  expect( assigns(:back_in_stock_notifications_summary).map{|v,c| [v.sku, c]} )
-                    .to eq [[variant_1.sku, 1], [variant_2.sku, 2]]
+                  expect(assigns(:back_in_stock_notifications_summary)).to eq [[variant_1, 1], [variant_2, 2]]
                 end
               end
             end
@@ -119,8 +117,7 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
 
               it "returns the expected results" do
                 subject
-                expect( assigns(:back_in_stock_notifications_summary).map{|v,c| [v.sku, c]} )
-                  .to eq [[variant_2.sku, 2]]
+                expect(assigns(:back_in_stock_notifications_summary)).to eq [[variant_2, 2]]
               end
             end
 

--- a/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
+++ b/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
@@ -115,12 +115,41 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
             end
 
             context "filter by UK stock location" do
-              let(:params) { {stock_location_id: uk_stock_location.id} }
+              let(:params) { {q: {stock_location_id_eq: uk_stock_location.id}} }
 
               it "returns the expected results" do
                 subject
                 expect( assigns(:back_in_stock_notifications_summary).map{|v,c| [v.sku, c]} )
                   .to eq [[variant_2.sku, 2]]
+              end
+            end
+
+            context "requested 0, 2, and 4 days ago" do
+              before do
+                uk_back_in_stock_notification_1.update_column :updated_at, 2.days.ago
+                uk_back_in_stock_notification_2.update_column :updated_at, 4.days.ago
+              end
+
+              context "filter by start date of three days ago" do
+                let(:params) { {q: {updated_at_gt: 3.days.ago.strftime("%Y-%m-%d")}} }
+
+                context "with no end date" do
+                  it "returns the results from two requests" do
+                    subject
+                    expect(assigns(:back_in_stock_notifications_summary)).to eq [[variant_2, 1], [variant_1, 1]]
+                  end
+                end
+
+                context "with an end date of yesterday" do
+                  before do
+                    params[:q][:updated_at_lt] = 1.day.ago.strftime("%Y-%m-%d")
+                  end
+
+                  it "returns the results from 1 request" do
+                    subject
+                    expect(assigns(:back_in_stock_notifications_summary)).to eq [[variant_2, 1]]
+                  end
+                end
               end
             end
           end

--- a/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
+++ b/spec/controllers/spree/admin/back_in_stock_notifications_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Spree::Admin::BackInStockNotificationsController, type: :controll
                 context "with no end date" do
                   it "returns the results from two requests" do
                     subject
-                    expect(assigns(:back_in_stock_notifications_summary)).to eq [[variant_2, 1], [variant_1, 1]]
+                    expect(assigns(:back_in_stock_notifications_summary)).to match_array [[variant_2, 1], [variant_1, 1]]
                   end
                 end
 


### PR DESCRIPTION
To help admin users see which out of stock items have been requested in the last week or month, date selection fields are added to the summary page and the date field included in the CSV download. To help user understand which variants are most popular the options text is also included on the summary page.

![Screenshot from 2024-01-24 10-29-06](https://github.com/watg/solidus_back_in_stock/assets/3398855/3fb04ca1-d76d-46d0-aa77-e07b235d663b)
